### PR TITLE
Add the List Template message plugin

### DIFF
--- a/src/Message/ListMessage.php
+++ b/src/Message/ListMessage.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @file
+ * Contains Drupal\fb_messenger_bot\Message\ListMessage.
+ */
+
+namespace Drupal\fb_messenger_bot\Message;
+
+/**
+ * Class ListMessage.
+ *
+ * @package Drupal\fb_messenger_bot
+ */
+class ListMessage implements MessageInterface {
+
+  /**
+   * A nested array of list elements.
+   */
+  protected $listElements;
+
+  /**
+   * ListMessage constructor.
+   *
+   * @param string $listElements
+   *   The elements array.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown if the $buttons argument contains invalid objects.
+   *
+   * @todo: Add verification that the URL is actually an image.
+   */
+  public function __construct($listElements) {
+    if (is_array($listElements)) {
+      $this->listElements = $listElements;
+    }
+    else {
+      throw new \InvalidArgumentException("Invalid elements array.");
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormattedMessage() {
+    return [
+      'attachment' => [
+        'type' => 'template',
+        'payload' => [
+          'template_type' => 'list',
+          'elements' => $this->listElements,
+        ],
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
The List Template is very useful and can likely be easily adapted to use it inside workflows with Drupal content. See: https://developers.facebook.com/docs/messenger-platform/send-api-reference/list-template